### PR TITLE
Added code to clip out-of-dwi fiber coordinates

### DIFF
--- a/life/fe/feConnectomeEncoding.m
+++ b/life/fe/feConnectomeEncoding.m
@@ -112,7 +112,13 @@ fibers = cell2mat(fibers(:)');
 
 % Compute voxels
 voxel_coord = round(fibers) + 1;
+
+% Clip coordinates to within imgsize
 voxel_coord(voxel_coord<1)=1;
+voxel_coord(1, voxel_coord(1,:)>imgsize(1))=imgsize(1);
+voxel_coord(2, voxel_coord(2,:)>imgsize(2))=imgsize(2);
+voxel_coord(3, voxel_coord(3,:)>imgsize(3))=imgsize(3);
+
 cols = sub2ind(imgsize, voxel_coord(1,:)', voxel_coord(2,:)', voxel_coord(3,:)');
 
 % Compute atoms

--- a/life/fe/feConnectomeSetDwi.m
+++ b/life/fe/feConnectomeSetDwi.m
@@ -41,6 +41,15 @@ fe  = feSet(fe, sprintf('diffusion bvals %s',tag), ...
             dwiGet(dwi, 'diffusion bvals'));
 fe  = feSet(fe, sprintf('bvecs indices %s',tag),   ...
             dwiGet(dwi, 'diffusionimagenums'));
+        
+        
+dim = dwi.nifti.dim;
+coords = fe.roi.coords;
+coords(coords<1)=1;
+coords(coords(:,1)>dim(1), 1)=dim(1);
+coords(coords(:,2)>dim(2), 2)=dim(2);
+coords(coords(:,3)>dim(3), 3)=dim(3);
+fe.roi.coords = coords;
 
 % Extract the dwi signal at the coordinates of the connectome
 fe  = feSet(fe, sprintf('diffusion signal image %s',tag), ...

--- a/life/utility/fefgGet.m
+++ b/life/utility/fefgGet.m
@@ -221,7 +221,6 @@ switch strrep(lower(param),' ','')
     % matrix of integers.
     % val = round(horzcat(fg.fibers{:})'); 
     val = round(horzcat(fg.fibers{:})')+1;
-    val(val<1)=1;
     val = unique(val,'rows');
     
     case {'allimagecoords'}


### PR DESCRIPTION
Updated clipping code to handle fiber coordinates overflow (the previous patch only deals with underflow)